### PR TITLE
Add example script for converting tiff stack from a mounted google drive to zarr

### DIFF
--- a/examples/convert_tiffs_to_zarr.py
+++ b/examples/convert_tiffs_to_zarr.py
@@ -6,26 +6,23 @@ array, and then saves it as a chunked zarr file.
 """
 
 import shutil
-from pathlib import Path
 
 from stack_to_chunk import MultiScaleGroup
-from stack_to_chunk.tiff_helpers import read_tiff_stack_with_dask
+from stack_to_chunk.io_helpers import load_env_var_as_path, read_tiff_stack_with_dask
 
-# Define path to the Google Drive folder containing data for all subjects
-gdrive_dir = Path("/Users/nsirmpilatze/GDrive")
-project_dir = (
-    gdrive_dir / "Shared drives/Cummings and O'Connell Collaboration/Tadpoles/"
-)
-assert project_dir.is_dir()
+# Paths to the Google Drive folder containing tiffs for all subjects & channels
+# and the output folder for the zarr files (both set as environment variables)
+input_dir = load_env_var_as_path("ATLAS_PROJECT_TIFF_INPUT_DIR")
+output_dir = load_env_var_as_path("ATLAS_PROJECT_ZARR_OUTPUT_DIR")
 
 # Define subject ID and check that the corresponding folder exists
 subject_id = "topro35"
-assert (project_dir / subject_id).is_dir()
+assert (input_dir / subject_id).is_dir()
 
 # Define channel (by wavelength) and check that there is exactly one folder
 # containing the tiff files for this channel in the subject folder
 channel = "488"
-channel_dirs = sorted(project_dir.glob(f"{subject_id}/*{channel}*"))
+channel_dirs = sorted(input_dir.glob(f"{subject_id}/*{channel}*"))
 assert len(channel_dirs) == 1
 channel_dir = channel_dirs[0]
 
@@ -36,10 +33,7 @@ chunk_size = 64
 if __name__ == "__main__":
 
     tiff_files = sorted(channel_dir.glob("*.tif"))
-
-    # Define output directory and create a folder for the subject and channel
-    output_dir = Path("/Users/nsirmpilatze/Data/tadpoles")
-    assert output_dir.is_dir()
+    # Create a folders for the subject and channel in the output directory
     zarr_file_path = output_dir / subject_id / f"{subject_id}_{channel}.zarr"
     if zarr_file_path.exists():
         print(f"Deleting existing {zarr_file_path}")
@@ -53,12 +47,14 @@ if __name__ == "__main__":
         voxel_sizes=(3, 3, 3),
     )
 
-    # Add the full resolution data
-    stack = read_tiff_stack_with_dask(channel_dir)
-    stack = stack.transpose((2, 1, 0))
+    # Read the tiff stack into a dask array
+    da_arr = read_tiff_stack_with_dask(channel_dir)
+    da_arr = da_arr.transpose((2, 1, 0))
+    da_arr.rechunk(chunks=(da_arr.shape[0], da_arr.shape[1], 1))
 
+    # Add the dask array to the zarr group
     group.add_full_res_data(
-        stack,
+        da_arr,
         n_processes=5,
         chunk_size=chunk_size,
         compressor="default",

--- a/examples/convert_tiffs_to_zarr.py
+++ b/examples/convert_tiffs_to_zarr.py
@@ -1,0 +1,65 @@
+"""
+An example script to convert a multi-tiff stack to a chunked zarr file.
+
+This script loads the multi-tiff stack from a Google Drive folder into a dask
+array, and then saves it as a chunked zarr file.
+"""
+
+import shutil
+from pathlib import Path
+
+from stack_to_chunk import MultiScaleGroup
+from stack_to_chunk.tiff_helpers import read_tiff_stack_with_dask
+
+# Define path to the Google Drive folder containing data for all subjects
+gdrive_dir = Path("/Users/nsirmpilatze/GDrive")
+project_dir = (
+    gdrive_dir / "Shared drives/Cummings and O'Connell Collaboration/Tadpoles/"
+)
+assert project_dir.is_dir()
+
+# Define subject ID and check that the corresponding folder exists
+subject_id = "topro35"
+assert (project_dir / subject_id).is_dir()
+
+# Define channel (by wavelength) and check that there is exactly one folder
+# containing the tiff files for this channel in the subject folder
+channel = "488"
+channel_dirs = sorted(project_dir.glob(f"{subject_id}/*{channel}*"))
+assert len(channel_dirs) == 1
+channel_dir = channel_dirs[0]
+
+# Select chunk size
+chunk_size = 64
+
+
+if __name__ == "__main__":
+
+    tiff_files = sorted(channel_dir.glob("*.tif"))
+
+    # Define output directory and create a folder for the subject and channel
+    output_dir = Path("/Users/nsirmpilatze/Data/tadpoles")
+    assert output_dir.is_dir()
+    zarr_file_path = output_dir / subject_id / f"{subject_id}_{channel}.zarr"
+    if zarr_file_path.exists():
+        print(f"Deleting existing {zarr_file_path}")
+        shutil.rmtree(zarr_file_path)
+
+    # Create a MultiScaleGroup object (zarr group)
+    group = MultiScaleGroup(
+        zarr_file_path,
+        name=f"{subject_id}_{channel}",
+        spatial_unit="micrometer",
+        voxel_sizes=(3, 3, 3),
+    )
+
+    # Add the full resolution data
+    stack = read_tiff_stack_with_dask(channel_dir)
+    stack = stack.transpose((2, 1, 0))
+
+    group.add_full_res_data(
+        stack,
+        n_processes=5,
+        chunk_size=chunk_size,
+        compressor="default",
+    )

--- a/src/stack_to_chunk/io_helpers.py
+++ b/src/stack_to_chunk/io_helpers.py
@@ -4,12 +4,28 @@ Utility functions for reading tiff files.
 Copied and modified from brainglobe/cellfinder and brainglobe/brainglobe-utils.
 """
 
+import os
 from pathlib import Path
 
 import dask.array as da
 from dask.delayed import delayed
 from numpy.typing import DTypeLike
 from tifffile import TiffFile, imread
+
+
+def load_env_var_as_path(env_var: str) -> Path:
+    """Load an environment variable as a Path object."""
+    path_str = os.getenv(env_var)
+
+    if path_str is None:
+        msg = f"Please set the environment variable {env_var}."
+        raise ValueError(msg)
+
+    path = Path(path_str)
+    if not path.is_dir():
+        msg = f"{path} is not a valid directory path."
+        raise ValueError(msg)
+    return path
 
 
 def get_tiff_meta(

--- a/src/stack_to_chunk/tiff_helpers.py
+++ b/src/stack_to_chunk/tiff_helpers.py
@@ -1,0 +1,73 @@
+"""
+Utility functions for reading tiff files.
+
+Copied and modified from brainglobe/cellfinder and brainglobe/brainglobe-utils.
+"""
+
+from pathlib import Path
+
+import dask.array as da
+from dask.delayed import delayed
+from numpy.typing import DTypeLike
+from tifffile import TiffFile, imread
+
+
+def get_tiff_meta(
+    path: Path,
+) -> tuple[tuple[int, int], DTypeLike]:
+    """
+    Get the shape and dtype of the first page of a tiff file.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to the tiff file.
+
+    Returns
+    -------
+    tuple[tuple[int, int], np.dtype]
+        Shape and dtype of the first page.
+
+    """
+    with TiffFile(path) as tfile:
+        nz = len(tfile.pages)
+        if not nz:
+            msg = f"tiff file {path} has no pages!"
+            raise ValueError(msg)
+        first_page = tfile.pages[0]
+
+    return tfile.pages[0].shape, first_page.dtype
+
+
+def read_tiff_stack_with_dask(path: Path) -> da.Array:
+    """
+    Read a stack of tiff files into a dask array.
+
+    Based on https://github.com/tlambert03/napari-ndtiffs
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to the folder containing the tiff files, or
+        a text file containing the paths to the tiff files.
+
+    Returns
+    -------
+    da.Array
+        Dask array of the tiff stack.
+
+    """
+    if path.suffix == ".txt":
+        with path.open("r") as f:
+            file_paths = [Path(line.rstrip()) for line in f.readlines()]
+    else:
+        file_paths = sorted(path.glob("*.tif"))
+
+    shape, dtype = get_tiff_meta(file_paths[0])
+    lazy_imread = delayed(imread)
+    lazy_arrays = [lazy_imread(fn) for fn in sorted(file_paths)]
+    dask_arrays = [
+        da.from_delayed(delayed_reader, shape=shape, dtype=dtype)
+        for delayed_reader in lazy_arrays
+    ]
+    return da.stack(dask_arrays, axis=0)


### PR DESCRIPTION
This script assumes that the google drive folder has been locally synced.
The input (google drive) and output folders are read from environment variables.

This script currently errors with:
```sh
ValueError: axes don't match array
```

We suspect this has somehow to do with the chunking.